### PR TITLE
fixed:修复群英榜自动开始

### DIFF
--- a/src/game/mgr/HeroRankMgr.js
+++ b/src/game/mgr/HeroRankMgr.js
@@ -168,6 +168,10 @@ export default class HeroRankMgr {
             this.clear();
             return false;
         }
+		if(this.shouldStartFight())
+		{
+			this.lock = false;
+		}
         return true;
     }
 


### PR DESCRIPTION
之前发现群英榜不会自动开始,是因为判断的问题,加了一行代码,已经可以了
![image](https://github.com/user-attachments/assets/c810ccba-b669-48d6-8edc-55a0217e2c7d)
